### PR TITLE
tray.c: #include common.h

### DIFF
--- a/src/tray.c
+++ b/src/tray.c
@@ -21,6 +21,7 @@
  */
 
 #include "tray.h"
+#include "common.h"
 #include "../pixmaps/rip1.xpm"
 #include "../pixmaps/menuplay.xpm"
 #include "../pixmaps/menupause.xpm"


### PR DESCRIPTION
This is needed for Loadxpm()'s prototype, which is needed on
x86_64 as it returns a pointer.

closes dwest/grip#8
