### PR TITLE
cddev.c CDStat(): Handle ioctl(CDROMSUBCHNL) -> CDAUDIO_NOSTATUS

### DIFF
--- a/src/cddev.c
+++ b/src/cddev.c
@@ -269,6 +269,9 @@ gboolean CDStat(DiscInfo *disc,gboolean read_toc)
         cdsc.cdsc_absaddr.msf.frame;
 
     switch(cdsc.cdsc_audiostatus) {
+    case CDROM_AUDIO_INVALID:
+        disc->disc_mode=CDAUDIO_NOSTATUS;
+        break;
     case CDROM_AUDIO_PLAY:
         disc->disc_mode=CDAUDIO_PLAYING;
         break;


### PR DESCRIPTION
When the CDROMSUBCHNL ioctl() returns cdsc_audiostatus=CDROM_AUDIO_INVALID,
we need to set disc_mode=CDAUDIO_NOSTATUS.

Leaving disc_mode unchanged in this case seems to leave it 0, which is
CDAUDIO_PLAYING, which causes confusion trying to select tracks to edit.

closes dwest/grip#10
